### PR TITLE
Change data type from Array{T,1} to AbstractArray{T,1}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllanDeviations"
 uuid = "3997ae70-a3ff-11e8-15d8-f1cc36d21cef"
 authors = ["Julien Kluge <Julien.Kluge@gmail.com>"]
-version = "0.2.1"
+version = "0.1.1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AllanDeviations"
 uuid = "3997ae70-a3ff-11e8-15d8-f1cc36d21cef"
 authors = ["Julien Kluge <Julien.Kluge@gmail.com>"]
-version = "0.1.0"
+version = "0.2.1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/AllanDeviations.jl
+++ b/src/AllanDeviations.jl
@@ -36,7 +36,7 @@ struct Decade <: AllanTauDescriptor end
 #
 # Helper Functions/
 #
-function frequencytophase(data::Array{T, 1}, rate::AbstractFloat) where T
+function frequencytophase(data::AbstractArray{T, 1}, rate::AbstractFloat) where T
 	dt = 1 / rate
 	n = length(data) + 1
 	dataPrime = zeros(T, n)

--- a/src/dev_allan.jl
+++ b/src/dev_allan.jl
@@ -16,7 +16,7 @@ Calculates the allan deviation
 * `count`:		Number of contributing terms for each deviation.
 """
 function allandev(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/src/dev_hadamard.jl
+++ b/src/dev_hadamard.jl
@@ -16,7 +16,7 @@ Calculates the hadamard deviation
 * `count`:		Number of contributing terms for each deviation.
 """
 function hadamarddev(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/src/dev_mallan.jl
+++ b/src/dev_mallan.jl
@@ -16,7 +16,7 @@ Calculates the modified allan deviation
 * `count`:		Number of contributing terms for each deviation.
 """
 function mallandev(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/src/dev_mtie.jl
+++ b/src/dev_mtie.jl
@@ -22,7 +22,7 @@ Calculates the maximal time interval error
 * `count`:		Number of contributing terms for each deviation.
 """
 function mtie(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/src/dev_time.jl
+++ b/src/dev_time.jl
@@ -16,7 +16,7 @@ Calculates the time deviation
 * `count`:		Number of contributing terms for each deviation.
 """
 function timedev(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/src/dev_total.jl
+++ b/src/dev_total.jl
@@ -16,7 +16,7 @@ Calculates the total deviation
 * `count`:		Number of contributing terms for each deviation.
 """
 function totaldev(
-		data::Array{T, 1},
+		data::AbstractArray{T, 1},
 		rate::AbstractFloat;
 		frequency::Bool = false,
 		overlapping::Bool = true,

--- a/test/test_general.jl
+++ b/test/test_general.jl
@@ -1,6 +1,8 @@
 using Test
-using AllanDeviations
 using Random
+
+include("../src/AllanDeviations.jl")
+using .AllanDeviations
 
 arrInt = zeros(Int, 5)
 arr32 = zeros(Float32, 5)


### PR DESCRIPTION
Allow more types of data vectors as input than `Array{T,1}`.

For example, [CSV.jl](https://github.com/JuliaData/CSV.jl)  can output a column of type `SentinelArrays.ChainedVector{Float64, Vector{Float64}}` which is a subtype of `AbstractArray{T,1}`, but not a subtype of `Array{T,1}`.